### PR TITLE
content does not span all columns

### DIFF
--- a/lib/redmine_multi_column_custom_fields/issues_helper_patch.rb
+++ b/lib/redmine_multi_column_custom_fields/issues_helper_patch.rb
@@ -38,7 +38,7 @@ module RedmineMultiColumnIssuesHelperPatch
         ordered_values.compact.each do |value|
           if value.custom_field.multi_column?
             s << "</tr><tr>\n"
-            s << "<td colspan='0'><div class='wiki'>\n"
+            s << "<td colspan='4'><div class='wiki'>\n"
             s << "<hr />\n"
             s << "<p><strong>#{ h(value.custom_field.name) }</strong></p><br />\n"
             s << "<p>#{ simple_format_without_paragraph(h(show_value(value))) }</p>\n"


### PR DESCRIPTION
On redmine 3.0.1 and chrome, the colspan='0' attribute reserves the space for the whole line, but the actual cell content is limited to one column, whereas with colspan='4' the content truely spans all the columns
